### PR TITLE
Decouple chatbot code from Facebook Messenger, add JS wit-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "test": "mocha-webpack",
     "test:watch": "mocha-webpack --watch",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "wit-client": "babel-node ./wit-client.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "mocha-webpack",
     "test:watch": "mocha-webpack --watch",
     "lint": "eslint src",
-    "wit-client": "babel-node ./wit-client.js"
+    "wit-client": "babel-node ./wit-client.js",
     "cover": "cross-env NODE_ENV=coverage nyc --reporter=lcov --reporter=text npm run test",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   }

--- a/src/facebook-messenger/handler.js
+++ b/src/facebook-messenger/handler.js
@@ -15,7 +15,7 @@ module.exports.handler = (event, context, cb) => {
       .catch(err => cb(err));
 
   } else if (event.method === 'POST') {
-    const wit = new WitAI();
+    const wit = new WitAI(Messenger.send.bind(Messenger));
 
     return Messenger.receive(event.body, wit)
       .then(response => cb(null, response))

--- a/src/wit-ai/wit-ai.service.js
+++ b/src/wit-ai/wit-ai.service.js
@@ -2,15 +2,14 @@ import { Wit, log } from 'node-wit';
 
 import Sessions from './sessions.service';
 
-// FIXME: uncouple fb-messenger service
-import FBMessenger from '../facebook-messenger/messenger.service';
-
 
 module.exports = class WitAI {
-    constructor() {
+    constructor(sendAction) {
         if (!process.env.WIT_AI_TOKEN) {
             throw new Error('No WIT_AI_TOKEN defined');
         }
+
+        this.sendAction = sendAction;
 
         this.wit = new Wit({
             accessToken: process.env.WIT_AI_TOKEN,
@@ -44,7 +43,7 @@ module.exports = class WitAI {
     }
 
     send({sessionId}, {text}) {
-        return FBMessenger.send(sessionId, text).then(() => null);
+        return this.sendAction(sessionId, text).then(() => null);
     }
 
     set_name({context, entities}) {

--- a/src/wit-ai/wit-ai.service.js
+++ b/src/wit-ai/wit-ai.service.js
@@ -27,7 +27,10 @@ module.exports = class WitAI {
 
     receive(sessionId, text) {
         return this.sessions.read(sessionId)
-            .catch(() => { return {}; })
+            .catch(err => {
+                console.error(err.message.toString());
+                return {};
+            })
             .then(context => {
                 return this.wit.runActions(
                     sessionId,

--- a/test/facebook-messenger/messenger.service.test.js
+++ b/test/facebook-messenger/messenger.service.test.js
@@ -52,11 +52,11 @@ describe('Facebook Messenger service', function() {
                 fs.readFileSync('./test/data/event-fbmessage.json')
             );
 
-            this.cb = sinon.stub();
+            this.cb = { receive: sinon.stub() };
         });
 
         afterEach(function() {
-            this.cb.reset();
+            this.cb.receive.reset();
         });
 
         it('should return a Promise', function() {
@@ -71,7 +71,7 @@ describe('Facebook Messenger service', function() {
             const ret = this.Messenger.receive(this.data.body, this.cb);
 
             return expect(ret).to.eventually.be.fulfilled.then(() => {
-                return expect(this.cb).to.have.been.calledWith(
+                return expect(this.cb.receive).to.have.been.calledWith(
                     'USER_ID', "hello, world!"
                 );
             });

--- a/wit-client.js
+++ b/wit-client.js
@@ -1,0 +1,13 @@
+import { interactive } from 'node-wit';
+
+import WitAI from './src/wit-ai/wit-ai.service';
+
+require('./src/lib/envVars').config();
+
+
+const wit = new WitAI(function(session, message) {
+    console.log(message);
+    return Promise.resolve();
+});
+interactive(wit.wit);
+


### PR DESCRIPTION
Changed wit-service to take a callback for sending messages.
Added a JS wit-client runnable with `npm run wit-client` for debugging Wit-ai and Wit-ai service code.
