### PR TITLE
Bring chatbot api more in line with Bot Framework

### DIFF
--- a/src/chatbot/builder.js
+++ b/src/chatbot/builder.js
@@ -64,16 +64,17 @@ module.exports = class Dialog {
             userData: session.getUserData(),
             input: input || session.getInput()
         };
-        const promise = this._actions[actionId](actionData).then((result) => {
-            if (result.context) {
-                log.debug("Updating context: {0}", JSON.stringify(result.context));
-                session.setContext(result.context);
-            }
-            if (result.userData) {
-                log.debug("Updating userData: {0}", JSON.stringify(result.userData));
-                session.setUserData(result.userData);
-            }
-        });
+        const promise = Promise.resolve(this._actions[actionId](actionData))
+            .then((result) => {
+                if (result.context) {
+                    log.debug("Updating context: {0}", JSON.stringify(result.context));
+                    session.setContext(result.context);
+                }
+                if (result.userData) {
+                    log.debug("Updating userData: {0}", JSON.stringify(result.userData));
+                    session.setUserData(result.userData);
+                }
+            });
 
         return promise;
     }

--- a/src/chatbot/builder.js
+++ b/src/chatbot/builder.js
@@ -14,7 +14,7 @@ module.exports = class Dialog {
         this._strings = strings;
     }
 
-    addState(stateId, substates, intents=[]) {
+    dialog(stateId, substates, intents=[]) {
         if (stateId.startsWith('/')) {
             stateId = stateId.substr(1);
         }
@@ -28,14 +28,14 @@ module.exports = class Dialog {
         return this;
     }
 
-    addIntent(intentId, intentObj) {
+    intent(intentId, intentObj) {
         log.debug("Registering intent {0}", intentId);
         this._intents[intentId] = intentObj;
 
         return this;
     }
 
-    addAction(actionId, fn) {
+    action(actionId, fn) {
         log.debug("Registering action {0}", actionId);
         this._actions[actionId] = fn;
 
@@ -244,8 +244,10 @@ module.exports = class Dialog {
 
                 return resolve(
                     session.runQueue().then(() => {
-                        if (!session.done) {
+                        if (session.getState() !== state || session.getSubState() !== substate) {
                             return this._runStep(step+1, session, input);
+                        } else {
+                            session.next();
                         }
                     })
                 );

--- a/src/chatbot/coaching-chatbot.dialog.js
+++ b/src/chatbot/coaching-chatbot.dialog.js
@@ -1,40 +1,36 @@
-import Dialog from './dialog';
+import Builder from './builder';
 
 import strings from './coaching-chatbot.strings.json';
 import * as actions from './coaching-chatbot.actions';
 import * as intents from './coaching-chatbot.intents';
 
 
-const dialog = new Dialog(strings);
+const bot = new Builder(strings);
 
 // ACTIONS
 for (let actionId in actions) {
-    dialog.addAction(actionId, actions[actionId]);
+    bot.action(actionId, actions[actionId]);
 }
 
 // INTENTS
 for (let intentId in intents) {
-    dialog.addIntent(intentId, intents[intentId]);
+    bot.intent(intentId, intents[intentId]);
 }
 
-// STATES
-dialog
-    .addState(
-        '/base',
+// DIALOGS
+bot
+    .dialog(
+        '/',
         [
             (session) => {
                 session.addResult("@greeting");
-                session.next();
-                session.endDialog();
             },
             (session) => {
                 if (session.checkIntent('yes')) {
-                    session.pushState('/create_profile');
+                    session.beginDialog('/create_profile');
 
                 } else if (session.checkIntent('no')) {
                     session.addResult("@goodbye");
-                    session.popState();
-                    session.endDialog();
 
                 } else {
                     session.addResult("@unclear");
@@ -44,122 +40,111 @@ dialog
         ],
         [
             ['reset', (session) => {
-                session.runAction('reset');
+                session.runActions(['reset']);
                 session.addResult('@reset');
                 session.clearState();
             }]
         ])
-    .addState(
+    .dialog(
         '/create_profile',
         [
             (session) => {
                 session.addResult("@great");
-                session.next();
-                session.pushState('/set_name');
+                session.beginDialog('/set_name');
             },
             (session) => {
-                session.next();
-                session.pushState('/set_job');
+                session.beginDialog('/set_job');
             },
             (session) => {
-                session.switchState('/profile');
+                session.switchDialog('/profile');
             }
         ])
-    .addState(
+    .dialog(
         '/set_name',
         [
             (session) => {
                 session.addResult("@request_name");
-                session.next();
-                session.endDialog();
             },
             (session) => {
-                session.runAction('set_name');
+                session.runActions(['set_name']);
                 session.addResult('@confirm_name');
-                session.popState();
+                session.endDialog();
             }
         ])
-    .addState(
+    .dialog(
         '/set_job',
         [
             (session) => {
                 session.addResult('@request_job');
-                session.next();
-                session.endDialog();
             },
             (session) => {
-                session.runAction('set_job');
-                session.popState();
+                session.runActions(['set_job']);
+                session.endDialog();
             }
         ])
-    .addState(
+    .dialog(
         '/set_age',
         [
             (session) => {
                 session.addResult('@request_age');
-                session.next();
-                session.endDialog();
             },
             (session) => {
-                session.runAction('set_age');
+                session.runActions(['set_age']);
                 session.addResult('@confirm_age');
-                session.popState();
+                session.endDialog();
             }
         ])
-    .addState(
+    .dialog(
         '/set_place',
         [
             (session) => {
                 session.addResult('@request_place');
-                session.next();
-                session.endDialog();
             },
             (session) => {
-                session.runAction('set_place');
+                session.runActions(['set_place']);
                 session.addResult('@confirm_place');
-                session.popState();
+                session.endDialog();
             }
         ])
-    .addState(
+    .dialog(
         '/profile',
         [
             (session) => {
-                session.runAction('update_profile');
+                session.runActions(['update_profile']);
                 session.addResult('@display_profile');
-                session.endDialog();
             }
         ],
         [
             ['change_name', (session, match) => {
                 if (match !== true) {
-                    session.runAction('set_name', match);
+                    session.runActions(['set_name'], match);
                     session.addResult('@confirm_name');
                 } else {
-                    session.pushState('/set_name');
+                    session.beginDialog('/set_name');
                 }
             }],
             ['change_job', (session, match) => {
                 if (match !== true) {
-                    session.runAction('set_job', match);
+                    session.runActions(['set_job'], match);
                     session.addResult('@confirm_job');
                 } else {
-                    session.pushState('/set_job');
+                    session.beginDialog('/set_job');
                 }
             }],
             ['set_age', (session, match) => {
                 if (match !== true) {
-                    session.runAction('set_age', match);
+                    session.runActions(['set_age'], match);
                     session.addResult('@confirm_age');
                 } else {
-                    session.pushState('/set_age');
+                    session.beginDialog('/set_age');
                 }
             }],
             ['set_place', (session, match) => {
                 if (match !== true) {
-                    session.runAction('set_place', match);
+                    session.runActions(['set_place'], match);
                     session.addResult('@confirm_place');
                 } else {
-                    session.pushState('/set_place');
+                    session.beginDialog('/set_place');
                 }
             }],
             ['find_pair', (session) => {
@@ -167,4 +152,4 @@ dialog
             }],
         ]);
 
-module.exports = dialog;
+module.exports = bot;

--- a/src/chatbot/session.js
+++ b/src/chatbot/session.js
@@ -143,9 +143,7 @@ module.exports = class Session {
 
         for (let i = 0; i < actionArr.length; ++i) {
             this._queue = this._queue.then(
-                Promise.resolve(
-                    this.dialog.runAction(actionArr[i], this, input)
-                )
+                this.dialog.runAction(actionArr[i], this, input)
             );
         }
     }


### PR DESCRIPTION
Dialog class:
 - Rename Dialog class to Builder
 - Rename builder.addState() to builder.dialog()
 - Rename builder.addIntent() to builder.intent()
 - Rename builder.addAction() to builder.action()

Session class:
 - Update behaviour of session.next() to closer match bot framework:
   - calling next() skips to next state without returning to user
   - not calling next() stops bot execution and awaits user response
 - Remove old implementation of session.endDialog()
 - Rename session.popState() to session.endDialog()
 - Rename session.pushState() to session.beginDialog()
 - Rename session.switchState() to session.switchDialog()
   - *switchState functionality not in bot framework?*
 - Rename session.runAction() to session.runActions(), add array support