### PR TITLE
Add support for quick replies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Copy this file as .env and add your tokens
 FACEBOOK_PAGE_ACCESS_TOKEN=
 FACEBOOK_VERIFY_TOKEN=
+LOGLEVEL=4

--- a/scripts/bot-client.js
+++ b/scripts/bot-client.js
@@ -40,7 +40,13 @@ function interactive(bot) {
 
     bot.receive(sessionId, line)
       .then((msg) => {
-        console.log('\x1b[93m' + msg.join('\n'));
+        for (let i = 0; i < msg.length; ++i) {
+          let { message, quickReplies } = msg[i];
+          console.log('\x1b[93m' + message + '\x1b[39m');
+          if (quickReplies.length) {
+            console.log(formatQuickReplies(quickReplies));
+          }
+        }
         rl.prompt();
       })
       .catch((err) => console.error(err.stack));
@@ -49,5 +55,15 @@ function interactive(bot) {
   rl.setPrompt('\x1b[0m> ');
   rl.prompt();
 };
+
+function formatQuickReplies(quickReplies) {
+  let out = [];
+
+  for (let i = 0; i < quickReplies.length; ++i) {
+    out.push('\x1b[7m ' + quickReplies[i].name + ' \x1b[27m');
+  }
+
+  return out.join(' ');
+}
 
 main();

--- a/src/chatbot/builder.js
+++ b/src/chatbot/builder.js
@@ -1,5 +1,4 @@
 import log from '../lib/logger-service';
-import Formatter from '../lib/personal-information-formatter-service';
 
 import Session from './session';
 
@@ -110,10 +109,14 @@ module.exports = class Builder {
     return match || false;
   }
 
-  getFormattedString(stringId, variables) {
-    log.debug('Retrieving string {0}', stringId);
-    log.debug('Retrieving string {0}', JSON.stringify(variables));
-    return Formatter.formatFromTemplate(stringId, variables);
+  getStringTemplate(templateId) {
+    log.debug('Retrieving string template {0}', templateId);
+
+    let template = this._strings[templateId];
+    if (Array.isArray(template)) {
+      template = template[Math.floor(Math.random() * template.length)];
+    }
+    return (template === undefined) ? templateId : template;
   }
 
   getSubStateCount(stateId) {

--- a/src/chatbot/session.js
+++ b/src/chatbot/session.js
@@ -1,5 +1,5 @@
 import log from '../lib/logger-service';
-
+import Formatter from '../lib/personal-information-formatter-service';
 
 module.exports = class Session {
     constructor(dialog) {
@@ -71,11 +71,22 @@ module.exports = class Session {
 
     /**
     * Add a response to give to the user
-    * @param {string} stringId ID of the string template to use
+    * @param {string} templateId ID of the string template to use
+    * @param {Array<{name: string, payload: string}>} quickReplies
     */
-    addResult(stringId) {
-        log.debug('Adding result: {0}', stringId);
-        this._results.push(stringId);
+    addResult(templateId, quickReplies) {
+        let template = this.dialog.getStringTemplate(templateId);
+        this.send(template, quickReplies);
+    }
+
+    /**
+    * Add a response to give to the user
+    * @param {string} message The message to send to the user
+    * @param {Array<{name: string, payload: string}>} quickReplies
+    */
+    send(message, quickReplies) {
+        log.debug('Adding result: {0}', message);
+        this._results.push(message);
     }
 
     /**
@@ -173,16 +184,14 @@ module.exports = class Session {
     }
 
     getResult() {
-        let result = [];
+      let result = [];
 
-        for (let i = 0; i < this._results.length; ++i) {
-            result.push(
-                this.dialog.getFormattedString(
-                    this._results[i], this.getVariables())
-            );
-        }
+      for (let i = 0; i < this._results.length; ++i) {
+        result.push(
+            Formatter.format(this._results[i], this.getVariables()));
+      }
 
-        return result;
+      return result;
     }
 
     get stateId() {

--- a/src/coaching-chatbot/dialog.js
+++ b/src/coaching-chatbot/dialog.js
@@ -25,7 +25,8 @@ bot
   .dialog(
     '/', [
       (session) => {
-        session.addResult('@GREETING');
+        session.addResult('@GREETING',
+            [{ name: '@YES' }, { name: '@NO' }]);
       },
       (session) => {
         if (session.checkIntent('yes')) {

--- a/test/ft/feature-tests.js
+++ b/test/ft/feature-tests.js
@@ -6,10 +6,12 @@ import Strings from '../../src/coaching-chatbot/strings.json';
 const SESSION = 'SESSION';
 
 function buildResponse(templateId, quickReplies=[]) {
-  return {
-    message: Strings[templateId],
-    quickReplies: []
-  };
+  let message = Strings[templateId];
+  if (message === undefined) {
+    message = templateId;
+  }
+
+  return { message, quickReplies };
 }
 
 describe('User story', function() {
@@ -40,10 +42,11 @@ describe('User story', function() {
     function() {
       it('When the user sends a greeting MB should respond to the user',
         function() {
-          return expect(
-              this.bot.receive(SESSION, 'moi')
-            )
-            .to.eventually.become([Strings['@GREETING']]);
+          return expect(this.bot.receive(SESSION, 'moi'))
+              .to.eventually.become([
+                  buildResponse('@GREETING',
+                      [{ 'name': 'Kyllä' }, { 'name': 'Ei' }]),
+              ]);
         });
     });
 
@@ -55,8 +58,11 @@ describe('User story', function() {
         function() {
           const promise = this.bot.receive(SESSION, 'invalid input');
           return promise.then((ret) => {
-            expect(Strings['@UNCLEAR']).to.include(ret[0]);
-            expect(ret[1]).to.deep.equal(Strings['@GREETING']);
+            expect(Strings['@UNCLEAR']).to.include(ret[0].message);
+            expect(ret[1]).to.deep.equal(
+                buildResponse('@GREETING',
+                    [{ 'name': 'Kyllä' }, { 'name': 'Ei' }])
+            );
           });
         }
       );
@@ -72,8 +78,10 @@ describe('User story', function() {
           return expect(
               this.bot.receive(SESSION, 'Kyllä')
             )
-            .to.eventually.become([Strings['@GREAT'], Strings[
-              '@REQUEST_NAME']]);
+            .to.eventually.become([
+                buildResponse('@GREAT'),
+                buildResponse('@REQUEST_NAME'),
+            ]);
         });
     });
 
@@ -85,12 +93,13 @@ describe('User story', function() {
         function() {
           this.userInformation.name = this.expectedName;
           return expect(
-              this.bot.receive(SESSION, this.userInformation.name)
+                this.bot.receive(SESSION, this.userInformation.name)
             )
-            .to.eventually.become([Formatter.formatFromTemplate(
-                '@CONFIRM_NAME', this.userInformation),
-              Strings[
-                '@REQUEST_JOB']
+            .to.eventually.become([
+                buildResponse(
+                    Formatter.formatFromTemplate(
+                        '@CONFIRM_NAME', this.userInformation)),
+                buildResponse('@REQUEST_JOB'),
             ]);
         });
     });
@@ -98,7 +107,6 @@ describe('User story', function() {
   describe(
     'As a registered user I want to provide my occupation to the bot so other people can see it and bot will show the information and asks for additional information',
     function() {
-
       it(
         'should ask user for a occupation when user has provided his/her name',
         function() {
@@ -106,8 +114,11 @@ describe('User story', function() {
           return expect(
               this.bot.receive(SESSION, this.userInformation.job)
             )
-            .to.eventually.become([Formatter.formatFromTemplate(
-              '@DISPLAY_PROFILE', this.userInformation)]);
+            .to.eventually.become([
+              buildResponse(
+                  Formatter.formatFromTemplate(
+                      '@DISPLAY_PROFILE', this.userInformation)),
+            ]);
         });
     });
 
@@ -119,13 +130,16 @@ describe('User story', function() {
         function() {
           this.userInformation.age = this.expectedAge;
           return expect(
-              this.bot.receive(SESSION, 'Lisää ikä ' + this.userInformation
-                .age)
-            )
-
-            .to.eventually.become([Formatter.formatFromTemplate(
-                '@CONFIRM_AGE', this.userInformation),
-              Formatter.formatFromTemplate('@DISPLAY_PROFILE', this.userInformation)
+              this.bot.receive(
+                  SESSION,
+                      'Lisää ikä ' + this.userInformation.age))
+            .to.eventually.become([
+              buildResponse(
+                  Formatter.formatFromTemplate(
+                      '@CONFIRM_AGE', this.userInformation)),
+              buildResponse(
+                  Formatter.formatFromTemplate(
+                      '@DISPLAY_PROFILE', this.userInformation)),
             ]);
         });
     });
@@ -137,12 +151,16 @@ describe('User story', function() {
         'should ask user for a additional information when user has provided his/her name and occupation',
         function() {
           this.userInformation.place = this.expectedPlace;
+
           return expect(
-              this.bot.receive(SESSION, 'Lisää paikkakunta ' + this.userInformation
-                .place)
-            )
-            .to.eventually.become([Strings['@CONFIRM_PLACE'],
-              Formatter.formatFromTemplate('@DISPLAY_PROFILE', this.userInformation)
+              this.bot.receive(
+                  SESSION,
+                      'Lisää paikkakunta ' + this.userInformation.place))
+            .to.eventually.become([
+              buildResponse('@CONFIRM_PLACE'),
+              buildResponse(
+                  Formatter.formatFromTemplate(
+                      '@DISPLAY_PROFILE', this.userInformation)),
             ]);
         });
     });

--- a/test/ft/feature-tests.js
+++ b/test/ft/feature-tests.js
@@ -5,6 +5,13 @@ import Strings from '../../src/coaching-chatbot/strings.json';
 
 const SESSION = 'SESSION';
 
+function buildResponse(templateId, quickReplies=[]) {
+  return {
+    message: Strings[templateId],
+    quickReplies: []
+  };
+}
+
 describe('User story', function() {
   before(function() {
     let context = {};

--- a/test/ut/facebook-messenger/messenger-service-tests.js
+++ b/test/ut/facebook-messenger/messenger-service-tests.js
@@ -10,7 +10,7 @@ describe('Facebook Messenger service', function() {
         this.request = sinon.stub().returns(Promise.resolve());
 
         this.Messenger = mod({
-            'request-promise': this.request
+            'request-promise': this.request,
         });
 
         process.env.FACEBOOK_PAGE_ACCESS_TOKEN = 'DUMMY_ACCESS_TOKEN';
@@ -62,7 +62,10 @@ describe('Facebook Messenger service', function() {
 
             this.cb = {
                 receive: sinon.stub()
-                .returns(Promise.resolve(['hello, world!'])),
+                    .returns(Promise.resolve([{
+                        message: 'hello, world!',
+                        quickReplies: [],
+                    }])),
             };
         });
 
@@ -76,7 +79,7 @@ describe('Facebook Messenger service', function() {
 
         it('should call callback with the message sender and body', function() {
             const mock = sinon.mock(this.Messenger);
-            mock.expects('send').withArgs('USER_ID', 'hello, world!');
+            mock.expects('send').withArgs('USER_ID', 'hello, world!', []);
 
             const ret = this.Messenger.receive(this.data.body, this.cb);
 


### PR DESCRIPTION
`Session.addResult()` now takes a quick reply array as it's second argument.
Added new method `Session.send(message, quickReplies)`

ChatbotService.receive() now resolves into an array of `{ message: "", quickReplies: [{ name, payload }] }` objects.