### PR TITLE
Fix DynamoDB condition expression for listing pairs

### DIFF
--- a/src/util/sessions-dynamodb-provider.js
+++ b/src/util/sessions-dynamodb-provider.js
@@ -80,8 +80,8 @@ module.exports = class DynamoDBProvider {
         TableName: this.SESSION_TABLE,
         Limit: 50,
         FilterExpression: 'context.searching = :true AND ' +
-                          'context.meetingFrequency = :freq' +
-                          'id != :id',
+                          'context.meetingFrequency = :freq AND ' +
+                          'NOT id = :id',
         ExpressionAttributeValues: { ':true': true,
                                      ':freq': meetingFrequency,
                                      ':id': id },


### PR DESCRIPTION
Minimal change, fixes syntax of DynamoDB filter expr.
Basically, listing available pairs should work now...